### PR TITLE
Allow opaque retailer filter ids in catalog search

### DIFF
--- a/src/core/catalog-helper.service.ts
+++ b/src/core/catalog-helper.service.ts
@@ -85,16 +85,6 @@ export class CatalogHelperService {
   }
 
   /**
-   * Validates if a string is a valid MongoDB ObjectId format
-   * @param {string} id - The string to validate
-   * @returns {boolean} - Whether the string is a valid ObjectId format
-   */
-  private isValidObjectId(id: string): boolean {
-    if (!id || typeof id !== 'string') return false;
-    return /^[0-9a-fA-F]{24}$/.test(id);
-  }
-
-  /**
    * Validates the retailers array parameter
    * @param {string[]} retailers - Array of retailer IDs to validate
    * @param {string[]} errors - Array to collect validation errors
@@ -113,8 +103,8 @@ export class CatalogHelperService {
         retailers.forEach((retailerId, index) => {
           if (typeof retailerId !== 'string') {
             errors.push(`Retailer at index ${index} must be a string`);
-          } else if (!this.isValidObjectId(retailerId)) {
-            errors.push(`Retailer ID at index ${index} must be a valid ObjectId string`);
+          } else if (retailerId.trim() === '') {
+            errors.push(`Retailer ID at index ${index} must be a non-empty string`);
           }
         });
       }

--- a/tests/core/catalog-helper.service.spec.ts
+++ b/tests/core/catalog-helper.service.spec.ts
@@ -1,0 +1,36 @@
+import { CatalogHelperService } from '../../src/core/catalog-helper.service';
+
+describe('CatalogHelperService', () => {
+  const locationServiceHelper = {
+    validateAndNormalizeLocation: vi.fn(),
+  };
+
+  beforeEach(() => {
+    locationServiceHelper.validateAndNormalizeLocation.mockClear();
+  });
+
+  it('accepts non-ObjectId retailer filter strings during search validation', () => {
+    const service = new CatalogHelperService(locationServiceHelper as any);
+
+    const result = service.validateAndNormalizeSearchParams({
+      query: 'bourbon',
+      retailers: ['accelpay-retailer-123'],
+      loc: { zip: '10001' } as any,
+    } as any);
+
+    expect(result.error).toBeUndefined();
+    expect(locationServiceHelper.validateAndNormalizeLocation).toHaveBeenCalled();
+  });
+
+  it('rejects empty retailer filter strings during search validation', () => {
+    const service = new CatalogHelperService(locationServiceHelper as any);
+
+    const result = service.validateAndNormalizeSearchParams({
+      query: 'bourbon',
+      retailers: [''],
+      loc: { zip: '10001' } as any,
+    } as any);
+
+    expect(result.error).toContain('Retailer ID at index 0 must be a non-empty string');
+  });
+});


### PR DESCRIPTION
## Summary
- relax catalog retailer filter validation to accept opaque string ids instead of requiring Mongo ObjectIds
- add focused coverage for retailer filter normalization

## Why
AccelPay-backed catalog/search flows need Cloud SDK callers to treat retailer filter ids as opaque values during migration, rather than assuming ReserveBar Mongo id format.

## Verification
- pnpm exec vitest run tests/core/catalog-helper.service.spec.ts
- pnpm exec biome check src/core/catalog-helper.service.ts tests/core/catalog-helper.service.spec.ts
  - returns one pre-existing warning in catalog-helper.service.ts for an unused private member
- git diff --check