### PR TITLE
feat: support Google Places session tokens

### DIFF
--- a/src/interfaces/address.interface.ts
+++ b/src/interfaces/address.interface.ts
@@ -75,9 +75,12 @@ export interface ILocBase extends ICoreParams {
  * @extends ICoreParams
  *
  * @property {string} input - The user's input string for address lookup.
+ * @property {string} [sessionToken] - The Google Places session token for the autocomplete session.
  */
 export interface IAddressAutocompleteParams extends ICoreParams {
   input: string;
+
+  sessionToken?: string;
 }
 
 /**
@@ -102,9 +105,12 @@ export interface IAddressAutocompleteResult {
  *
  * Properties:
  *  - id: Represents the unique identifier for the address details.
+ *  - sessionToken: The optional Google Places session token used for autocomplete.
  */
 export interface IAddressDetailsParams extends ICoreParams {
   id: string;
+
+  sessionToken?: string;
 }
 
 /**

--- a/tests/address.service.test.ts
+++ b/tests/address.service.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AuthenticatedService } from '../src/core/authenticated.service';
+import { LIQUID_COMMERCE_ENV } from '../src/enums';
+import { AddressService } from '../src/services/address.service';
+
+const createClient = () =>
+  new AuthenticatedService({
+    apiKey: 'liquid-api-key',
+    baseURL: 'https://cloud.example/',
+    env: LIQUID_COMMERCE_ENV.PROD,
+  });
+
+const successfulResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+describe('AddressService', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('forwards the Places session token in autocomplete requests', async () => {
+    const fetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(
+        successfulResponse({
+          data: {
+            token: 'access-token',
+            exp: Date.now() + 60_000,
+          },
+        })
+      )
+      .mockResolvedValueOnce(successfulResponse({ data: [] }));
+    vi.stubGlobal('fetch', fetch);
+    const service = new AddressService(createClient());
+
+    await service.autocomplete(
+      {
+        input: '123 Main',
+        sessionToken: 'places-session-token',
+      },
+      'google-places-api-key'
+    );
+
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      'https://cloud.example/api/address/autocomplete',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          input: '123 Main',
+          sessionToken: 'places-session-token',
+          key: 'google-places-api-key',
+        }),
+      })
+    );
+  });
+
+  it('forwards the Places session token in details requests', async () => {
+    const fetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(
+        successfulResponse({
+          data: {
+            token: 'access-token',
+            exp: Date.now() + 60_000,
+          },
+        })
+      )
+      .mockResolvedValueOnce(successfulResponse({ data: {} }));
+    vi.stubGlobal('fetch', fetch);
+    const service = new AddressService(createClient());
+
+    await service.details(
+      {
+        id: 'google-place-id',
+        sessionToken: 'places-session-token',
+      },
+      'google-places-api-key'
+    );
+
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      'https://cloud.example/api/address/details',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          id: 'google-place-id',
+          sessionToken: 'places-session-token',
+          key: 'google-places-api-key',
+        }),
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Adds an optional `sessionToken` to the autocomplete and place-details parameter contracts.
- Verifies both public address methods forward the token in their outbound request bodies.
- Leaves existing consumers and runtime behavior unchanged.

## Why

The SDK runtime already forwards extra parameters, but its public TypeScript contract prevented clients from intentionally supplying one token across Google Places autocomplete and Details. Without that shared token, a completed selection cannot terminate and redeem the autocomplete session.

## Compatibility

This is additive. Existing deployments and consumers that do not pass `sessionToken` behave exactly as before.

## Validation

- `pnpm test` — 2/2 tests passed
- `pnpm exec tsc --noEmit`
- Production build and generated declarations checked