### PR TITLE
Promote beta to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.10.0-beta.11](https://github.com/liquidcommerce/cloud-sdk/compare/v1.10.0-beta.10...v1.10.0-beta.11) (2026-07-29)
+
+
+### Features
+
+* support Places session tokens ([3498a49](https://github.com/liquidcommerce/cloud-sdk/commit/3498a498660b89234a70e463284b86ccd081af4c))
+
 # [1.10.0-beta.10](https://github.com/liquidcommerce/cloud-sdk/compare/v1.10.0-beta.9...v1.10.0-beta.10) (2026-05-27)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
  "name": "@liquidcommerceteam/cloud-sdk",
- "version": "1.10.0-beta.10",
+ "version": "1.10.0-beta.11",
  "description": "LiquidCommerce Cloud SDK",
  "main": "./dist/index.cjs",
  "module": "./dist/index.esm.js",

--- a/src/interfaces/address.interface.ts
+++ b/src/interfaces/address.interface.ts
@@ -75,9 +75,12 @@ export interface ILocBase extends ICoreParams {
  * @extends ICoreParams
  *
  * @property {string} input - The user's input string for address lookup.
+ * @property {string} [sessionToken] - The Google Places session token for the autocomplete session.
  */
 export interface IAddressAutocompleteParams extends ICoreParams {
   input: string;
+
+  sessionToken?: string;
 }
 
 /**
@@ -102,9 +105,12 @@ export interface IAddressAutocompleteResult {
  *
  * Properties:
  *  - id: Represents the unique identifier for the address details.
+ *  - sessionToken: The optional Google Places session token used for autocomplete.
  */
 export interface IAddressDetailsParams extends ICoreParams {
   id: string;
+
+  sessionToken?: string;
 }
 
 /**

--- a/tests/address.service.test.ts
+++ b/tests/address.service.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AuthenticatedService } from '../src/core/authenticated.service';
+import { LIQUID_COMMERCE_ENV } from '../src/enums';
+import { AddressService } from '../src/services/address.service';
+
+const createClient = () =>
+  new AuthenticatedService({
+    apiKey: 'liquid-api-key',
+    baseURL: 'https://cloud.example/',
+    env: LIQUID_COMMERCE_ENV.PROD,
+  });
+
+const successfulResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+describe('AddressService', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('forwards the Places session token in autocomplete requests', async () => {
+    const fetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(
+        successfulResponse({
+          data: {
+            token: 'access-token',
+            exp: Date.now() + 60_000,
+          },
+        })
+      )
+      .mockResolvedValueOnce(successfulResponse({ data: [] }));
+    vi.stubGlobal('fetch', fetch);
+    const service = new AddressService(createClient());
+
+    await service.autocomplete(
+      {
+        input: '123 Main',
+        sessionToken: 'places-session-token',
+      },
+      'google-places-api-key'
+    );
+
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      'https://cloud.example/api/address/autocomplete',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          input: '123 Main',
+          sessionToken: 'places-session-token',
+          key: 'google-places-api-key',
+        }),
+      })
+    );
+  });
+
+  it('forwards the Places session token in details requests', async () => {
+    const fetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(
+        successfulResponse({
+          data: {
+            token: 'access-token',
+            exp: Date.now() + 60_000,
+          },
+        })
+      )
+      .mockResolvedValueOnce(successfulResponse({ data: {} }));
+    vi.stubGlobal('fetch', fetch);
+    const service = new AddressService(createClient());
+
+    await service.details(
+      {
+        id: 'google-place-id',
+        sessionToken: 'places-session-token',
+      },
+      'google-places-api-key'
+    );
+
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      'https://cloud.example/api/address/details',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          id: 'google-place-id',
+          sessionToken: 'places-session-token',
+          key: 'google-places-api-key',
+        }),
+      })
+    );
+  });
+});


### PR DESCRIPTION
Promotes beta to main for release.

## Changes
- feat: support Places session tokens (#153)

## Conflict resolution
- `package.json`: kept main's file as-is (name `@liquidcommerce/cloud-sdk`, version `1.12.1`) — semantic-release will bump the version on release, and the deploy workflow rewrites the package name per branch.
- `CHANGELOG.md`: kept main's history and added the `1.10.0-beta.11` section on top (same pattern as previous promotions).