### PR TITLE
feat(catalog): support delivery-first search intent

### DIFF
--- a/src/core/catalog-helper.service.ts
+++ b/src/core/catalog-helper.service.ts
@@ -133,6 +133,10 @@ export class CatalogHelperService {
     const errors: string[] = [];
     const normalizedParams = { ...params };
 
+    if (!normalizedParams.deliveryFirst) {
+      delete normalizedParams.deliveryFirst;
+    }
+
     this.validateRetailers(normalizedParams.retailers, errors);
     this.validateOrderBy(normalizedParams.orderBy, errors);
     this.validateOrderDirection(normalizedParams.orderDirection, errors);

--- a/src/core/catalog-helper.service.ts
+++ b/src/core/catalog-helper.service.ts
@@ -133,7 +133,12 @@ export class CatalogHelperService {
     const errors: string[] = [];
     const normalizedParams = { ...params };
 
-    if (!normalizedParams.deliveryFirst) {
+    if (
+      normalizedParams.deliveryFirst !== undefined &&
+      typeof normalizedParams.deliveryFirst !== 'boolean'
+    ) {
+      errors.push('deliveryFirst must be a boolean');
+    } else if (normalizedParams.deliveryFirst !== true) {
       delete normalizedParams.deliveryFirst;
     }
 

--- a/src/interfaces/catalog.interface.ts
+++ b/src/interfaces/catalog.interface.ts
@@ -110,6 +110,9 @@ export interface IFilter {
 export interface ICatalogParams extends ILocBase {
   search?: string;
 
+  /** Requests delivery-first result ordering for a resolved location. */
+  deliveryFirst?: boolean;
+
   pageToken?: string;
 
   entity?: string;

--- a/tests/catalog.service.test.ts
+++ b/tests/catalog.service.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AuthenticatedService } from '../src/core/authenticated.service';
+import { CatalogHelperService } from '../src/core/catalog-helper.service';
+import { LocationHelperService } from '../src/core/location-helper.service';
+import { LIQUID_COMMERCE_ENV } from '../src/enums';
+import type { ICatalogParams } from '../src/interfaces';
+import { CatalogService } from '../src/services/catalog.service';
+
+const createService = () =>
+  new CatalogService(
+    new AuthenticatedService({
+      apiKey: 'liquid-api-key',
+      baseURL: 'https://cloud.example/',
+      env: LIQUID_COMMERCE_ENV.PROD,
+    }),
+    new CatalogHelperService(new LocationHelperService())
+  );
+
+const successfulResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+const createFetch = () =>
+  vi
+    .fn<typeof globalThis.fetch>()
+    .mockResolvedValueOnce(
+      successfulResponse({
+        data: {
+          token: 'access-token',
+          exp: Date.now() + 60_000,
+        },
+      })
+    )
+    .mockResolvedValueOnce(successfulResponse({ products: [] }));
+
+const searchParams = {
+  search: 'whiskey',
+  page: 1,
+  perPage: 20,
+} satisfies ICatalogParams;
+
+describe('CatalogService', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps an existing catalog search request byte-identical', async () => {
+    const fetch = createFetch();
+    vi.stubGlobal('fetch', fetch);
+
+    await createService().search(searchParams);
+
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      'https://cloud.example/api/catalog/search',
+      expect.objectContaining({
+        method: 'POST',
+        body: '{"search":"whiskey","page":1,"perPage":20}',
+      })
+    );
+  });
+
+  it('omits deliveryFirst when it is false', async () => {
+    const fetch = createFetch();
+    vi.stubGlobal('fetch', fetch);
+
+    await createService().search({ ...searchParams, deliveryFirst: false });
+
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      'https://cloud.example/api/catalog/search',
+      expect.objectContaining({
+        method: 'POST',
+        body: '{"search":"whiskey","page":1,"perPage":20}',
+      })
+    );
+  });
+
+  it('serializes deliveryFirst when it is true', async () => {
+    const fetch = createFetch();
+    vi.stubGlobal('fetch', fetch);
+
+    await createService().search({ ...searchParams, deliveryFirst: true });
+
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      'https://cloud.example/api/catalog/search',
+      expect.objectContaining({
+        method: 'POST',
+        body: '{"search":"whiskey","page":1,"perPage":20,"deliveryFirst":true}',
+      })
+    );
+  });
+});

--- a/tests/catalog.service.test.ts
+++ b/tests/catalog.service.test.ts
@@ -43,6 +43,7 @@ const searchParams = {
 
 describe('CatalogService', () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -93,4 +94,18 @@ describe('CatalogService', () => {
       })
     );
   });
+
+	 it.each(['false', 1])('rejects a non-boolean deliveryFirst value (%s)', async (value) => {
+	   const fetch = vi.fn<typeof globalThis.fetch>();
+	   vi.stubGlobal('fetch', fetch);
+	   vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+	   await expect(
+	     createService().search({
+	       ...searchParams,
+	       deliveryFirst: value as unknown as boolean,
+	     })
+	   ).rejects.toThrow('deliveryFirst must be a boolean');
+	   expect(fetch).not.toHaveBeenCalled();
+	 });
 });


### PR DESCRIPTION
## Summary

- add the optional `deliveryFirst` catalog-search intent to the public SDK interface
- serialize the flag only when it is exactly `true`
- prove absent and `false` requests remain byte-identical to the existing request shape
- reject non-boolean runtime values instead of silently serializing truthy inputs

Tracking: [DELIV-2303](https://linear.app/accelpay/issue/DELIV-2303/add-address-resolved-delivery-first-ranking-to-catalog-search) · [authoritative spec](https://github.com/accelpay/minibar-app/blob/feature/deliv-2303-delivery-first/docs/superpowers/specs/2026-07-28-delivery-first-global-ordering.md)

## Compatibility

This is an additive, opt-in change. Existing callers send no new query parameter unless they explicitly request delivery-first ranking.

## Before ready for merge

- merge this beta-targeted PR, promote the change to `main`, and publish a new `@liquidcommerce/cloud-sdk` release
- update storefront-core's dependency and lockfile to that published release before [storefront-core #2](https://github.com/accelpay/storefront-core/pull/2) is finalized

## Verification

- `pnpm test` (2 files / 7 tests)
- `pnpm exec tsc --noEmit`
- `pnpm build`

## Coordinated PRs and merge sequence

Review may happen in parallel, but merge/deploy in this order:

1. [external-adapter-services #129](https://github.com/liquidcommerce/external-adapter-services/pull/129): merge and deploy the completeness contract.
2. [lc-platform #340](https://github.com/liquidcommerce/lc-platform/pull/340): merge and deploy the global ranking contract and search implementation.
3. **This PR — [cloud-sdk #157](https://github.com/liquidcommerce/cloud-sdk/pull/157)**: merge the beta PR, promote the change to `main`, publish a new `@liquidcommerce/cloud-sdk` release, and update storefront-core's dependency and lockfile before step 5.
4. [cloud #933](https://github.com/liquidcommerce/cloud/pull/933): refresh generated lc-platform types after step 2, then merge and deploy after steps 1–2.
5. [storefront-core #2](https://github.com/accelpay/storefront-core/pull/2): confirm this published SDK version and the Cloud rollout, run the no-op telemetry/cursor checks, then merge.
6. [minibar-app #6](https://github.com/accelpay/minibar-app/pull/6): update the submodule pin to the merged storefront-core `main` SHA, then merge and deploy Minibar last.

Review-ready. Merge and publish in step 3, after the upstream service contracts are deployed.
