### PR TITLE
feat(catalog): type default, price and catPath on IProductSize

### DIFF
--- a/src/interfaces/catalog.interface.ts
+++ b/src/interfaces/catalog.interface.ts
@@ -477,6 +477,20 @@ export interface IProductSizeAttributes {
  * Represents the size details of a product in an inventory system.
  *
  * @interface IProductSize
+ *
+ * @property {boolean} [default] - Whether this size is the default selection on the product
+ *                                 details page. Set from the partner's per-SKU flag when the
+ *                                 partner carries this size, otherwise from the catalog row's
+ *                                 own default. Sizes flagged here are returned first.
+ *                                 Optional: older API versions omit the key entirely, so
+ *                                 consumers should read it as
+ *                                 `sizes.find((s) => s.default) ?? sizes[0]`.
+ *
+ * @property {null | number} price - This size's own national price in minor units (cents);
+ *                                  `null` when no price is available - never `0`. The key is
+ *                                  always present. Reads `null` on every size until the
+ *                                  platform half ships, so consumers must keep the
+ *                                  `priceInfo` fallback.
  */
 export interface IProductSize {
   id: string;
@@ -488,6 +502,8 @@ export interface IProductSize {
   size: string;
 
   volume: string;
+
+  catPath: string;
 
   uom: string;
 
@@ -504,6 +520,10 @@ export interface IProductSize {
   attributes: IProductSizeAttributes;
 
   modalities?: ENUM_MODALITIES;
+
+  default?: boolean;
+
+  price: null | number;
 
   variants: IProductVariant[];
 }


### PR DESCRIPTION
Closes #156

Adds the size default-selection flag and per-size national price to `IProductSize`, plus `catPath` which cloud already serializes.

## Changes

| Field | Type | Notes |
| --- | --- | --- |
| `default` | `boolean` (optional) | Default selection on the PDP. Partner per-SKU flag first, catalog row default where the partner has none. Flagged sizes are returned first. |
| `price` | `null \| number` | This size's own national price in minor units (cents). `null` when unavailable — never `0`. |
| `catPath` | `string` | Already serialized by cloud; matches the shape used in `IProduct`, cart and checkout. |

Documentation lives in the interface-level JSDoc `@property` block, matching the house style used by `IProductSizeAttributes` alongside it.

## Notes on the two type choices

**`default` is optional, not required.** liquidcommerce/cloud#929 makes the field always present going forward, but the SDK is consumed by clients on older API versions where the key is genuinely absent from the response object (the issue measured `0 / 17` products exposing the key). Optional is the honest type, and it's what #156 asked for. Consumers should read it as:

```ts
sizes.find((s) => s.default) ?? sizes[0]
```

The `?? sizes[0]` tail is load-bearing — a production audit of 577 multi-size groupings found 12 with no size flagged.

**`price` is non-optional but nullable, on purpose.** The key is always present in the response; its value is `null` when no price is available. Per #156 it reads `null` on *every* size until liquidcommerce/lc-platform#337 lands the platform half, so **consumers must keep the `priceInfo` fallback**. That caveat is documented in the type itself so it's visible at the call site rather than only in the issue.

**No `isCatalogDefault`.** liquidcommerce/cloud#929 withdrew that field before any client consumed it. Confirmed it appears nowhere in this SDK, so there was no drafted PR to retarget.

## Verification

- Confirmed `IProductSize` is byte-identical between `beta` and `v1.13.0` before implementing — nothing landed in the interim, so the ask stood as written (#156 explicitly asked for this check).
- `pnpm tsc --noEmit` — clean. Worth confirming, since `default` is a reserved word (legal as a property name).
- `pnpm biome check` on the changed file — clean.
- `pnpm test` — 2/2 passing.
- `pnpm build` — verified all three fields reach `dist/types/interfaces/catalog.interface.d.ts`, the declarations consumers actually import.

## Scope caveat

This is the typings half only. It does not by itself unblock liquidcommerce/reservebar-app#1065: `default` needs cloud#929 in the deployed environment to carry a value, and `price` needs lc-platform#337 before it reads anything but `null`.
