### PR TITLE
Promote beta to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.10.0-beta.12](https://github.com/liquidcommerce/cloud-sdk/compare/v1.10.0-beta.11...v1.10.0-beta.12) (2026-08-21)
+
+
+### Features
+
+* **catalog:** type default, price and catPath on IProductSize ([ef9ceba](https://github.com/liquidcommerce/cloud-sdk/commit/ef9ceba1ce53712c9ee630fe6c37baf15841c8ba)), closes [cloud#929](https://github.com/cloud/issues/929) [cloud#929](https://github.com/cloud/issues/929) [#156](https://github.com/liquidcommerce/cloud-sdk/issues/156)
+
 # [1.10.0-beta.11](https://github.com/liquidcommerce/cloud-sdk/compare/v1.10.0-beta.10...v1.10.0-beta.11) (2026-07-29)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
  "name": "@liquidcommerceteam/cloud-sdk",
- "version": "1.10.0-beta.11",
+ "version": "1.10.0-beta.12",
  "description": "LiquidCommerce Cloud SDK",
  "main": "./dist/index.cjs",
  "module": "./dist/index.esm.js",

--- a/src/interfaces/catalog.interface.ts
+++ b/src/interfaces/catalog.interface.ts
@@ -477,6 +477,20 @@ export interface IProductSizeAttributes {
  * Represents the size details of a product in an inventory system.
  *
  * @interface IProductSize
+ *
+ * @property {boolean} [default] - Whether this size is the default selection on the product
+ *                                 details page. Set from the partner's per-SKU flag when the
+ *                                 partner carries this size, otherwise from the catalog row's
+ *                                 own default. Sizes flagged here are returned first.
+ *                                 Optional: older API versions omit the key entirely, so
+ *                                 consumers should read it as
+ *                                 `sizes.find((s) => s.default) ?? sizes[0]`.
+ *
+ * @property {null | number} price - This size's own national price in minor units (cents);
+ *                                  `null` when no price is available - never `0`. The key is
+ *                                  always present. Reads `null` on every size until the
+ *                                  platform half ships, so consumers must keep the
+ *                                  `priceInfo` fallback.
  */
 export interface IProductSize {
   id: string;
@@ -488,6 +502,8 @@ export interface IProductSize {
   size: string;
 
   volume: string;
+
+  catPath: string;
 
   uom: string;
 
@@ -504,6 +520,10 @@ export interface IProductSize {
   attributes: IProductSizeAttributes;
 
   modalities?: ENUM_MODALITIES;
+
+  default?: boolean;
+
+  price: null | number;
 
   variants: IProductVariant[];
 }


### PR DESCRIPTION
Promotes `beta` to `main` for release. Supersedes #159, which conflicted on release metadata.

## What ships

One source change — the typings half of #156:

| Field | Type | Notes |
| --- | --- | --- |
| `default` | `boolean` (optional) | Default selection on the PDP. Partner per-SKU flag first, catalog row default where the partner has none. |
| `price` | `null \| number` | Size's own national price in minor units (cents). `null` when unavailable — never `0`. |
| `catPath` | `string` | Already serialized by cloud; matches `IProduct`, cart and checkout. |

All three land on `IProductSize` in `src/interfaces/catalog.interface.ts` — additive only, no existing field changed or removed. Merged to `beta` via #158 (closes #156).

## Conflict resolution

A direct `beta` → `main` PR conflicted on `CHANGELOG.md` and `package.json`. This branch merges `origin/main` into `beta` and resolves both. `src/interfaces/catalog.interface.ts` auto-merged cleanly — the source change is byte-identical to `beta` (verified with `git diff origin/beta`).

- **`package.json`** — kept `main`'s `1.13.0`. semantic-release cuts the next version on `main` after merge; `beta`'s `1.10.0-beta.12` must not roll `main` back.
- **`CHANGELOG.md`** — kept **both** histories rather than discarding either side. `1.13.0` (Places session tokens) and `1.10.0-beta.12` (this change) are both real releases. Also dropped a duplicated `cloud#929` link the release bot emitted twice.

Same approach as the prior promotion, #155.

## Notes for review

**Non-breaking.** `default` is optional; `catPath`/`price` are additions to a response interface. No consumer's existing code stops typechecking. `price` is non-optional-but-nullable by design — the key is always present in the response.

**The fields are typed, not yet populated.** `price` reads `null` on every size until liquidcommerce/lc-platform#337 lands the platform half, so consumers must keep the `priceInfo` fallback — documented in the type itself. `default` needs liquidcommerce/cloud#929 deployed to carry a value. This release does not on its own unblock liquidcommerce/reservebar-app#1065.

**Branch divergence is expected.** `main` carried 17 release commits (`1.10.1` → `1.13.0`) that never flowed back to `beta` — the standing pattern for this repo, not drift introduced here. This merge reconciles them.

## Verification

Run on the merged tree, not just on `beta`:

- `pnpm tsc --noEmit` — clean.
- `pnpm test` — 2/2 passing.
- `pnpm biome check` — clean on the changed file.
- `pnpm build` — all three fields reach `dist/types/interfaces/catalog.interface.d.ts`, the declarations consumers import.
- Confirmed no conflict markers remain and `version` is `1.13.0`.

Note the repo's only test file (`tests/address.service.test.ts`) is a unit test with `fetch` stubbed — there is no e2e coverage here, so nothing in CI exercises a real backend. Confirming these fields are actually populated will need a live call once the cloud and platform halves deploy.
